### PR TITLE
feat(project.io): add cache mechanism to store and reuse existing ETLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ wheels/
 
 # Virtual environments
 .venv
+
+# created cache during application runtime
+projects/

--- a/backend/flow/flow.py
+++ b/backend/flow/flow.py
@@ -20,16 +20,16 @@ class DataFlow:
         logger.info(f"Step '{step_name}' added: {df.shape[0]} linhas, {df.shape[1]} colunas.")
 
     def show_summary(self) -> None:
-        print("\nResumo do fluxo:")
+        logger.info("\nResumo do fluxo:")
         for name, df in self.steps.items():
-            print(f"- {name}: {df.shape[0]} linhas | {df.shape[1]} colunas")
+            logger.info(f"- {name}: {df.shape[0]} linhas | {df.shape[1]} colunas")
 
     def get_steps(self) -> Dict[str, pd.DataFrame]:
         return self.steps
     
     def list_files(arquivos: List[str]) -> None:
         for idx, f in enumerate(arquivos):
-            print(f"[{idx}] {os.path.basename(f)}")
+            logger.info(f"[{idx}] {os.path.basename(f)}")
 
 
     def create_subflow(source_step: str, source_files: List[str], target_step: str, target_file: str) -> SubFlow:

--- a/backend/persistence/project_io.py
+++ b/backend/persistence/project_io.py
@@ -1,0 +1,62 @@
+import json
+import os
+from utils.logger import logger
+from flow.project import ETLProject, SubFlow
+import pandas as pd
+
+def save_project(project: ETLProject, directory: str = "projects"):
+    os.makedirs(directory, exist_ok=True)
+
+    json_path = os.path.join(directory, f"{project.name}.json")
+
+    project_dict = {
+        "name": project.name,
+        "steps": project.steps,
+        "subflows": [
+            {
+                "source_step": s.source_step,
+                "__source_file": s.source_files,
+                "target_step": s.target_step,
+                "target_file": s.target_file
+            }
+            for s in project.subflows
+        ]
+    }
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(project_dict, f, indent=2)
+
+    logger.info(f"✅ Projeto '{project.name}' salvo em {json_path}")
+
+def load_project(name: str, directory: str = "projects") -> ETLProject:
+    path = os.path.join(directory, f"{name}.json")
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Projeto '{name}' não encontrado em {directory}")
+    
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+        
+    # Carregar os DataFrames
+    dataframes = {}
+    for step, files in data["steps"].items():
+        dfs = []
+        for file in files:
+            if file.endswith(".csv"):
+                df = pd.read_csv(file, sep=";", encoding="latin-1")
+            elif file.endswith(".parquet"):
+                df = pd.read_parquet(file)
+            else:
+                continue
+            df["__source_file"] = os.path.basename(file)
+            dfs.append(df)
+            
+        dataframes[step] = pd.concat(dfs, ignore_index=True) if dfs else pd.DataFrame()
+        
+    subflows = [SubFlow(**s) for s in data["subflows"]]
+    
+    return ETLProject(
+        name=data["name"],
+        steps=data["steps"],
+        dataframes=dataframes,
+        subflows=subflows
+    )

--- a/backend/readers/duckdb_reader.py
+++ b/backend/readers/duckdb_reader.py
@@ -30,7 +30,7 @@ class DuckDBReader(DataReader):
                 else:
                     continue
 
-                df['__origem_file'] = file
+                df['__source_file'] = file
                 dataframes.append(df)
 
             except Exception as e:


### PR DESCRIPTION
Introduced select_or_create_project and save_project methods to enable persistent storage of ETL project configurations.
Projects are now saved as JSON files (e.g., test.json) that track source and target file paths, as well as transformation steps and subflows.
This allows previously created ETLs to be reloaded and reused, avoiding redundant definitions and improving workflow efficiency.